### PR TITLE
fix: NULL pointer dereferencement

### DIFF
--- a/main.c
+++ b/main.c
@@ -112,6 +112,8 @@ main(int argc, char *argv[])
 
 	altsz = argc + 1;
 	alts = calloc(altsz, sizeof(char *));
+        if (! alts)
+                errx(EXIT_FAILURE, "calloc");
 	alts[0] = domain;
 	for (i = 0; i < altsz; i++)
 		alts[i + 1] = argv[i];


### PR DESCRIPTION
This bug can occur prior to any chroot() + dropprivs(), so the crash is
triggered as root user.