### PR TITLE
Fix compilation (-Wmissing-prototypes)

### DIFF
--- a/extern.h
+++ b/extern.h
@@ -246,8 +246,8 @@ int		 dropprivs(void);
 int		 dropfs(const char *);
 int		 checkprivs(void);
 
-int		 sandbox_after();
-int		 sandbox_before();
+int		 sandbox_after(void);
+int		 sandbox_before(void);
 
 /*
  * Should we print debugging messages?


### PR DESCRIPTION
sandbox-pledge.c:33: warning: no previous prototype for 'sandbox_before'
sandbox-pledge.c:40: warning: no previous prototype for 'sandbox_after'
